### PR TITLE
Fix compilation error with latest NumPy versions

### DIFF
--- a/xclib/utils/_sparse.pyx
+++ b/xclib/utils/_sparse.pyx
@@ -194,7 +194,7 @@ def rank_data(b):
 def _rank(data, indices, indptr):
     cdef Py_ssize_t num_rows = indptr.size - 1
     cdef Py_ssize_t idx
-    cdef np.ndarray[np.int_t, ndim=1] rank = _np.empty(data.size, dtype='int')
+    cdef np.ndarray[np.int32_t, ndim=1] rank = _np.empty(data.size, dtype='int')
     for idx in range(num_rows):
         rank[indptr[idx]:indptr[idx+1]] = rank_data(-1*data[indptr[idx]:indptr[idx+1]])
     return rank
@@ -205,7 +205,7 @@ def _rank(data, indices, indptr):
 def _topk(data, indices, indptr, k, pad_ind, pad_val):
     cdef Py_ssize_t num_rows = indptr.size - 1
     cdef Py_ssize_t idx, num_el, start_idx, end_idx
-    cdef np.ndarray[np.int_t, ndim=2] ind = _np.full((num_rows, k), pad_ind, 'int', 'C')
+    cdef np.ndarray[np.int32_t, ndim=2] ind = _np.full((num_rows, k), pad_ind, 'int', 'C')
     cdef np.ndarray[np.float64_t, ndim=2] val = _np.full((num_rows, k), pad_val, 'float', 'C')
     for idx in range(num_rows):
         start_idx = indptr[idx]

--- a/xclib/utils/_sparse.pyx
+++ b/xclib/utils/_sparse.pyx
@@ -194,7 +194,7 @@ def rank_data(b):
 def _rank(data, indices, indptr):
     cdef Py_ssize_t num_rows = indptr.size - 1
     cdef Py_ssize_t idx
-    cdef np.ndarray[np.int32_t, ndim=1] rank = _np.empty(data.size, dtype='int')
+    cdef np.ndarray[np.int64_t, ndim=1] rank = _np.empty(data.size, dtype=np.int64)
     for idx in range(num_rows):
         rank[indptr[idx]:indptr[idx+1]] = rank_data(-1*data[indptr[idx]:indptr[idx+1]])
     return rank
@@ -205,7 +205,7 @@ def _rank(data, indices, indptr):
 def _topk(data, indices, indptr, k, pad_ind, pad_val):
     cdef Py_ssize_t num_rows = indptr.size - 1
     cdef Py_ssize_t idx, num_el, start_idx, end_idx
-    cdef np.ndarray[np.int32_t, ndim=2] ind = _np.full((num_rows, k), pad_ind, 'int', 'C')
+    cdef np.ndarray[np.int64_t, ndim=2] ind = _np.full((num_rows, k), pad_ind, np.int64, 'C')
     cdef np.ndarray[np.float64_t, ndim=2] val = _np.full((num_rows, k), pad_val, 'float', 'C')
     for idx in range(num_rows):
         start_idx = indptr[idx]


### PR DESCRIPTION
When trying to install pyxclib using pip with latest NumPy version, the following error occurs during compilation:

```
Error compiling Cython file:
...
cdef np.ndarray[np.int_t, ndim=1] rank = _np.empty(data.size, dtype='int')
^
xclib/utils/_sparse.pyx:197:23: Invalid type.
```
This error seems to be caused by the use of `np.int_t`, which is no longer supported in newer NumPy versions.

Environment details:
- Python version: 3.10.15
- NumPy version: 2.1.2

Proposed solution:
Replace `np.int_t` with `np.intp_t` in the affected files, particularly in `xclib/utils/_sparse.pyx`. This should resolve the compilation issue while maintaining compatibility across different platforms.

Steps to reproduce:
1. Set up a Python environment with NumPy 2.1.2
2. Run `pip install git+https://github.com/kunaldahiya/pyxclib`
3. Observe the compilation error

Please review the changes and let me know if any further modifications are needed.